### PR TITLE
Added support for printing the contents of the patch files

### DIFF
--- a/src/DbPatch/Command/Patch/Abstract.php
+++ b/src/DbPatch/Command/Patch/Abstract.php
@@ -54,8 +54,10 @@
  * @subpackage Command_Patch
  * @author Sandy Pleyte
  * @author Martijn De Letter
+ * @author Rudi de Vries
  * @copyright 2011 Sandy Pleyte
  * @copyright 2010-2011 Martijn De Letter
+ * @copyright 2013 Rudi de Vries
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link http://www.github.com/dbpatch/DbPatch
  * @since File available since Release 1.0.0
@@ -102,6 +104,12 @@ abstract class DbPatch_Command_Patch_Abstract
      * @return void
      */
     abstract function apply();
+
+    /**
+     * @abstract
+     * @return string
+     */
+    abstract function getContents();
 
     /**
      * @abstract

--- a/src/DbPatch/Command/Patch/PHP.php
+++ b/src/DbPatch/Command/Patch/PHP.php
@@ -40,8 +40,10 @@
  * @subpackage Command_Patch
  * @author Sandy Pleyte
  * @author Martijn De Letter
+ * @author Rudi de Vries
  * @copyright 2011 Sandy Pleyte
  * @copyright 2010-2011 Martijn De Letter
+ * @copyright 2013 Rudi de Vries
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link http://www.github.com/dbpatch/DbPatch
  * @since File available since Release 1.0.0
@@ -54,8 +56,10 @@
  * @subpackage Command_Patch
  * @author Sandy Pleyte
  * @author Martijn De Letter
+ * @author Rudi de Vries
  * @copyright 2011 Sandy Pleyte
  * @copyright 2010-2011 Martijn De Letter
+ * @copyright 2013 Rudi de Vries
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link http://www.github.com/dbpatch/DbPatch
  * @since File available since Release 1.0.0
@@ -92,19 +96,35 @@ class DbPatch_Command_Patch_PHP extends DbPatch_Command_Patch_Abstract
         }
 
         try {
-            
+
             $env = new DbPatch_Command_Patch_PHP_Environment();
             $env->setDb($this->getDb()->getAdapter())
                 ->setWriter($this->getWriter())
                 ->setConfig($this->getConfig())
                 ->install($phpFile);
-                
+
         } catch (Exception $e) {
             $this->getWriter()->line(sprintf('error php patch: %s', $e->getMessage()));
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContents()
+    {
+        $content = file_get_contents($this->filename);
+        if ($content == '') {
+            $this->writer->error(
+                sprintf('patch file %s is empty', $this->basename)
+            );
+            return false;
+        }
+
+        return $content;
     }
 
     /**
@@ -141,4 +161,4 @@ class DbPatch_Command_Patch_PHP extends DbPatch_Command_Patch_Abstract
         $this->writeFile($patchDirectory . '/' . $filename, $content);
     }
 }
- 
+

--- a/src/DbPatch/Command/Patch/SQL.php
+++ b/src/DbPatch/Command/Patch/SQL.php
@@ -40,8 +40,10 @@
  * @subpackage Command_Patch
  * @author Sandy Pleyte
  * @author Martijn De Letter
+ * @author Rudi de Vries
  * @copyright 2011 Sandy Pleyte
  * @copyright 2010-2011 Martijn De Letter
+ * @copyright 2013 Rudi de Vries
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link http://www.github.com/dbpatch/DbPatch
  * @since File available since Release 1.0.0
@@ -49,13 +51,15 @@
 
 /**
  * SQL Patch file
- * 
+ *
  * @package DbPatch
  * @subpackage Command_Patch
  * @author Sandy Pleyte
  * @author Martijn De Letter
+ * @author Rudi de Vries
  * @copyright 2011 Sandy Pleyte
  * @copyright 2010-2011 Martijn De Letter
+ * @copyright 2013 Rudi de Vries
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link http://www.github.com/dbpatch/DbPatch
  * @since File available since Release 1.0.0
@@ -75,17 +79,16 @@ class DbPatch_Command_Patch_SQL extends DbPatch_Command_Patch_Abstract
 
     /**
      * Apply SQL Patch
-     * 
+     *
      * @return bool
      */
     public function apply()
     {
         $this->writer->line('apply patch: ' . $this->basename);
-        $content = file_get_contents($this->data['filename']);
-        if ($content == '') {
-            $this->writer->error(
-                sprintf('patch file %s is empty', $this->data['basename'])
-            );
+
+        $content = $this->getContents();
+
+        if ($content === false) {
             return false;
         }
 
@@ -101,6 +104,22 @@ class DbPatch_Command_Patch_SQL extends DbPatch_Command_Patch_Abstract
             return false;
         }
         return true;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContents()
+    {
+        $content = file_get_contents($this->data['filename']);
+        if ($content == '') {
+            $this->writer->error(
+                sprintf('patch file %s is empty', $this->data['basename'])
+            );
+            return false;
+        }
+
+        return $content;
     }
 
     /**
@@ -140,8 +159,8 @@ class DbPatch_Command_Patch_SQL extends DbPatch_Command_Patch_Abstract
     /**
      * Fix "database schema has changed" error
      *
-     * The VACUUM option makes it harder to execute queries 
-     * while other session (i.e. import command) modify the 
+     * The VACUUM option makes it harder to execute queries
+     * while other session (i.e. import command) modify the
      * database. Reconnecting prevents the error.
      *
      * @return DbPatch_Command_Patch_SQL

--- a/src/DbPatch/Command/Print.php
+++ b/src/DbPatch/Command/Print.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * DbPatch
+ *
+ * Copyright (c) 2011, Sandy Pleyte.
+ * Copyright (c) 2010-2011, Martijn De Letter.
+ * Copyright (c) 2013, Rudi de Vries
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *  * Neither the name of the authors nor the names of his
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package DbPatch
+ * @subpackage Command
+ * @author Rudi de Vries
+ * @copyright 2013 Rudi de Vries
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @link http://www.github.com/dbpatch/DbPatch
+ * @since File available since Release 1.1.2
+ */
+
+/**
+ * Update command
+ *
+ * @package DbPatch
+ * @subpackage Command
+ * @author Rudi de Vries
+ * @copyright 2013 Rudi de Vries
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @link http://www.github.com/dbpatch/DbPatch
+ * @since File available since Release 1.1.2
+ */
+class DbPatch_Command_Print extends DbPatch_Command_Update
+{
+	/**
+     * @return void
+     */
+    public function execute()
+    {
+        $branch = $this->getBranch();
+        $force = ($this->console->issetOption('force')) ? true : false;
+        $addToChangelog = ($this->console->getOptionValue('add-to-changelog')) ? true : false;
+
+        if ($branch != self::DEFAULT_BRANCH) {
+            $this->writer->line('Branch: ' . $branch);
+        }
+
+        $latestPatchNumber = $this->getLastPatchNumber($branch);
+
+        $patchFiles = $this->getPatches($branch);
+
+        if (count($patchFiles) == 0) {
+            $this->writer->success("no update needed " . ($branch != self::DEFAULT_BRANCH ? 'for branch ' . $branch : ''));
+            return;
+        }
+
+        $this->writer->line(sprintf('found %d patch %s',
+            count($patchFiles),
+            (count($patchFiles) == 1) ? 'file' : 'files'
+        ));
+
+        $patchNumbersToSkip = $this->getPatchNumbersToSkip($this->console->getOptions(), $patchFiles);
+
+        if (count($patchNumbersToSkip)) {
+            $this->writer->line('Skip patchnumbers: ' . implode(',', $patchNumbersToSkip));
+        }
+
+        foreach ($patchFiles as $patchNr => $patchFile)
+        {
+            if (($patchFile->patch_number <> $latestPatchNumber + 1) && !$force) {
+                $this->writer->error(
+                    sprintf('expected patch number %d instead of %d (%s). Use --force to override this check.',
+                        $latestPatchNumber + 1,
+                        $patchFile->patch_number,
+                        $patchFile->basename
+                    )
+                );
+                return;
+            }
+
+            if (in_array($patchNr, $patchNumbersToSkip)) {
+                $this->writer->line('manually skipped patch ' . $patchFile->basename);
+                $this->addToChangelog($patchFile, 'manually skipped');
+                $latestPatchNumber = $patchFile->patch_number;
+                continue;
+            }
+
+            $this->writer->line('#Patch: ' . $patchFile->filename);
+            $this->writer->line($patchFile->getContents());
+
+            if ($addToChangelog) {
+                $this->addToChangelog($patchFile);
+            }
+
+            $latestPatchNumber = $patchFile->patch_number;
+        }
+    }
+
+    /**
+     * @param string $command Command name
+     * @return void
+     */
+    public function showHelp($command = 'print')
+    {
+        parent::showHelp($command);
+        $writer = $this->getWriter();
+        $writer
+        ->indent(2)->line('--skip=<int>       One or more patchnumbers seperated by a comma to skip')
+        ->indent(2)->line('--force            Force the update, and ignore missing patches')
+        ->indent(2)->line('--add-to-changelog Add printed patches to changelog')
+        ->line();
+    }
+}

--- a/src/DbPatch/Command/Runner.php
+++ b/src/DbPatch/Command/Runner.php
@@ -38,10 +38,8 @@
  *
  * @package DbPatch
  * @subpackage Command
- * @author Sandy Pleyte
- * @author Martijn De Letter
- * @copyright 2011 Sandy Pleyte
- * @copyright 2010-2011 Martijn De Letter
+ * @author Rudi de Vries
+ * @copyright 2013 Rudi de Vries
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link http://www.github.com/dbpatch/DbPatch
  * @since File available since Release 1.0.0
@@ -49,13 +47,11 @@
 
 /**
  * Handle all the available commands
- * 
+ *
  * @package DbPatch
  * @subpackage Command
- * @author Sandy Pleyte
- * @author Martijn De Letter
- * @copyright 2011 Sandy Pleyte
- * @copyright 2010-2011 Martijn De Letter
+ * @author Rudi de Vries
+ * @copyright 2013 Rudi de Vries
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link http://www.github.com/dbpatch/DbPatch
  * @since File available since Release 1.0.0
@@ -76,7 +72,7 @@ class DbPatch_Command_Runner
         return array(
             'help', 'create', 'remove', 'show',
             'status', 'sync', 'update', 'dump',
-            'info', 'setup'
+            'info', 'setup', 'print'
         );
 
     }
@@ -108,6 +104,8 @@ class DbPatch_Command_Runner
             case 'du' : $cmd = 'dump';
                         break;
             case 'in' : $cmd = 'info';
+                        break;
+            case 'pr' : $cmd = 'print';
                         break;
         }
 
@@ -161,7 +159,7 @@ class DbPatch_Command_Runner
 
     /**
      * Show help options of DbPatch
-     * 
+     *
      * @return void
      */
     public function showHelp()
@@ -179,6 +177,7 @@ class DbPatch_Command_Runner
                 ->indent(2)->line('dump       dump database')
                 ->indent(2)->line('info       show configuration')
                 ->indent(2)->line('setup      setup a new dbpatch config file')
+                ->indent(2)->line('print      print contents of not applied patches')
                 ->line()
                 ->line('see \'dbpatch help <command>\' for more information on a specific command');
     }


### PR DESCRIPTION
Added support for printing the contents of the patch files instead of executing them. With this option SQL changes can be output to STDOUT for handling updates to multiple databases in other ways.

Option --add-to-changlog, default value FALSE. If set to yes/true, the patches will be marked as applied. 
