### PR TITLE
Fixed exitcodes

### DIFF
--- a/src/DbPatch/Command/Patch/PHP.php
+++ b/src/DbPatch/Command/Patch/PHP.php
@@ -95,18 +95,11 @@ class DbPatch_Command_Patch_PHP extends DbPatch_Command_Patch_Abstract
             return false;
         }
 
-        try {
-
-            $env = new DbPatch_Command_Patch_PHP_Environment();
-            $env->setDb($this->getDb()->getAdapter())
-                ->setWriter($this->getWriter())
-                ->setConfig($this->getConfig())
-                ->install($phpFile);
-
-        } catch (Exception $e) {
-            $this->getWriter()->line(sprintf('error php patch: %s', $e->getMessage()));
-            return false;
-        }
+        $env = new DbPatch_Command_Patch_PHP_Environment();
+        $env->setDb($this->getDb()->getAdapter())
+            ->setWriter($this->getWriter())
+            ->setConfig($this->getConfig())
+            ->install($phpFile);
 
         return true;
     }

--- a/src/DbPatch/Command/Patch/SQL.php
+++ b/src/DbPatch/Command/Patch/SQL.php
@@ -92,17 +92,12 @@ class DbPatch_Command_Patch_SQL extends DbPatch_Command_Patch_Abstract
             return false;
         }
 
-        try {
-            $db = $this->getDb();
-            $db->import($this->data['filename']);
+        $db = $this->getDb();
+        $db->import($this->data['filename']);
 
-            // SQLite needs a reconnect after changing scheme
-            $this->fixSqliteSchemaChangedBug();
+        // SQLite needs a reconnect after changing scheme
+        $this->fixSqliteSchemaChangedBug();
 
-        } catch (Exception $e) {
-            $this->writer->error($e->getMessage());
-            return false;
-        }
         return true;
     }
 

--- a/src/DbPatch/Command/Update.php
+++ b/src/DbPatch/Command/Update.php
@@ -107,14 +107,14 @@ class DbPatch_Command_Update extends DbPatch_Command_Abstract
         foreach ($patchFiles as $patchNr => $patchFile)
         {
             if (($patchFile->patch_number <> $latestPatchNumber + 1) && !$force) {
-                $this->writer->error(
-                    sprintf('expected patch number %d instead of %d (%s). Use --force to override this check.',
-                            $latestPatchNumber + 1,
-                            $patchFile->patch_number,
-                            $patchFile->basename
+                throw new DbPatch_Exception(
+                    sprintf(
+                        'expected patch number %d instead of %d (%s). Use --force to override this check.',
+                        $latestPatchNumber + 1,
+                        $patchFile->patch_number,
+                        $patchFile->basename
                     )
                 );
-                return;
             }
 
             if (in_array($patchNr, $patchNumbersToSkip)) {
@@ -130,12 +130,11 @@ class DbPatch_Command_Update extends DbPatch_Command_Abstract
                     ->apply();
 
             if (!$result) {
-                return;
+                throw new DbPatch_Exception(sprintf('Running patch %d failed!', $patchNr));
             }
 
             $this->addToChangelog($patchFile);
             $latestPatchNumber = $patchFile->patch_number;
-
         }
     }
 


### PR DESCRIPTION
I've adjusted the code of the patch classes so exceptions which are generated there are not catched in the same class as well. This way the exceptions bubble up to the Application which can respond more appropriate.

As a result exceptions in the patch itself will cause an exitcode of 1, which I think is more correct. I my specific   case deployments using Capistrano will now fail if a DB patch fails.
